### PR TITLE
Update secnotas_tb.v

### DIFF
--- a/tutorial/ICESTICK/T19-secnotas/secnotas_tb.v
+++ b/tutorial/ICESTICK/T19-secnotas/secnotas_tb.v
@@ -18,7 +18,7 @@ wire ch_out;
 
 //-- Instanciar el componente y establecer el valor del divisor
 //-- Se pone un valor bajo para simular (de lo contrario tardaria mucho)
-secnotas #(.N0(2), .N1(3), .N2(4), .DUR(10))
+secnotas #(.N0(4), .N1(3), .N2(2), .DUR(10))
   dut(
     .clk(clk),
     .ch_out(ch_out)


### PR DESCRIPTION
in this way the first simulated note is the lowest (DO is a lower frequencies respect to MI)

I already corrected the code on your Wiki:
https://github.com/Obijuan/open-fpga-verilog-tutorial/wiki/Cap%C3%ADtulo-19%3A-Secuenciando-notas
