### PR TITLE
Fix memory variable in Makefile

### DIFF
--- a/tutorial/ICE40-HX8K_Breakout_Board/T01-setbit/Makefile
+++ b/tutorial/ICE40-HX8K_Breakout_Board/T01-setbit/Makefile
@@ -26,7 +26,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 CURRENT_DIR := $(notdir $(patsubst %/,%,$(dir $(MKFILE_PATH))))
 FILE = $(CURRENT_DIR)
-MEMORY = "1k"
+MEMORY = "8k"
 
 #-------------------------------------------------------
 #-- Objetivo por defecto: hacer simulacion y sintesis


### PR DESCRIPTION
Probado en placa de desarrollo 8k de Lattice.
Con 1k, salta un error diciendo que el encapsulado tq144 no tiene un pin llamado B5.